### PR TITLE
remove messages

### DIFF
--- a/commands/event_command.py
+++ b/commands/event_command.py
@@ -12,7 +12,7 @@ class EventCommand(Command):
 
     async def execute(self, ctx, *args):
         if not args:
-            await ctx.send(event_ui.usage_message())
+            await ctx.send(event_ui.usage_message(), delete_after=10)
             return
 
         args = args[0]
@@ -23,7 +23,7 @@ class EventCommand(Command):
 
             if action == "add":
                 if len(args) < 3 or len(args) > 4:
-                    await ctx.send(event_ui.add_usage_message())
+                    await ctx.send(event_ui.add_usage_message(), delete_after=10)
                     return
                 name = args[1]
                 try:
@@ -31,23 +31,26 @@ class EventCommand(Command):
                     due = datetime.fromisoformat(args[2])
                     info = args[3] if len(args) > 3 else "No extra event info provided."
                     event = service.create_event(name, assigned, due, info)
-                    await ctx.send(event_ui.event_added_message(event))
+                    await ctx.send(event_ui.event_added_message(event), delete_after=5)
                 except ValueError:
-                    await ctx.send(event_ui.invalid_date_message())
+                    await ctx.send(event_ui.invalid_date_message(), delete_after=10)
 
             elif action == "list":
                 events = service.list_events()
-                await ctx.send(event_ui.no_events_message() if not events else event_ui.events_list_message(events))
+                if not events:
+                    await ctx.send(event_ui.no_events_message(), delete_after=5)
+                else:
+                    await ctx.send(event_ui.events_list_message(events))
 
             elif action == "delete":
                 if len(args) < 2 or not args[1].isdigit():
-                    await ctx.send(event_ui.delete_usage_message())
+                    await ctx.send(event_ui.delete_usage_message(), delete_after=10)
                     return
                 deleted = service.delete_event(int(args[1]))
-                await ctx.send(event_ui.delete_result_message(deleted))
+                await ctx.send(event_ui.delete_result_message(deleted), delete_after=5)
 
             else:
-                await ctx.send(event_ui.unknown_action_message())
+                await ctx.send(event_ui.unknown_action_message(), delete_after=10)
 
     def get_help_text(self):
         return f"!{self.name} [add|list|delete] <name> <due-date> <info(optional)> - {self.description}"

--- a/commands/event_command.py
+++ b/commands/event_command.py
@@ -3,6 +3,7 @@ from services.event_service import EventService
 from db.base import get_session
 from datetime import datetime
 from ui import event_ui
+from core.constants import USAGE_MESSAGE_DISPLAY_TIME, FEEDBACK_MESSAGE_DISPLAY_TIME
 
 
 class EventCommand(Command):
@@ -12,7 +13,7 @@ class EventCommand(Command):
 
     async def execute(self, ctx, *args):
         if not args:
-            await ctx.send(event_ui.usage_message(), delete_after=10)
+            await ctx.send(event_ui.usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
             return
 
         args = args[0]
@@ -23,7 +24,7 @@ class EventCommand(Command):
 
             if action == "add":
                 if len(args) < 3 or len(args) > 4:
-                    await ctx.send(event_ui.add_usage_message(), delete_after=10)
+                    await ctx.send(event_ui.add_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
                     return
                 name = args[1]
                 try:
@@ -31,26 +32,26 @@ class EventCommand(Command):
                     due = datetime.fromisoformat(args[2])
                     info = args[3] if len(args) > 3 else "No extra event info provided."
                     event = service.create_event(name, assigned, due, info)
-                    await ctx.send(event_ui.event_added_message(event), delete_after=5)
+                    await ctx.send(event_ui.event_added_message(event), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
                 except ValueError:
-                    await ctx.send(event_ui.invalid_date_message(), delete_after=10)
+                    await ctx.send(event_ui.invalid_date_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
             elif action == "list":
                 events = service.list_events()
                 if not events:
-                    await ctx.send(event_ui.no_events_message(), delete_after=5)
+                    await ctx.send(event_ui.no_events_message(), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
                 else:
                     await ctx.send(event_ui.events_list_message(events))
 
             elif action == "delete":
                 if len(args) < 2 or not args[1].isdigit():
-                    await ctx.send(event_ui.delete_usage_message(), delete_after=10)
+                    await ctx.send(event_ui.delete_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
                     return
                 deleted = service.delete_event(int(args[1]))
-                await ctx.send(event_ui.delete_result_message(deleted), delete_after=5)
+                await ctx.send(event_ui.delete_result_message(deleted), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
 
             else:
-                await ctx.send(event_ui.unknown_action_message(), delete_after=10)
+                await ctx.send(event_ui.unknown_action_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
     def get_help_text(self):
         return f"!{self.name} [add|list|delete] <name> <due-date> <info(optional)> - {self.description}"

--- a/commands/help_command.py
+++ b/commands/help_command.py
@@ -17,12 +17,12 @@ class HelpCommand(Command):
         registry = CommandRegistry()
 
         if not role:
-            await ctx.send(help_ui.prompt_for_role())
+            await ctx.send(help_ui.prompt_for_role(), delete_after=10)
             return
 
         role = role.lower()
         if role not in ["student", "teacher"]:
-            await ctx.send(help_ui.unknown_role_message())
+            await ctx.send(help_ui.unknown_role_message(), delete_after=10)
             return
 
         commands = registry.get_commands_by_role(role)

--- a/commands/help_command.py
+++ b/commands/help_command.py
@@ -1,6 +1,7 @@
 from commands.base import Command
 from core.registry import CommandRegistry
 from ui import help_ui  # <- import UI helpers
+from core.constants import USAGE_MESSAGE_DISPLAY_TIME
 
 
 class HelpCommand(Command):
@@ -17,12 +18,12 @@ class HelpCommand(Command):
         registry = CommandRegistry()
 
         if not role:
-            await ctx.send(help_ui.prompt_for_role(), delete_after=10)
+            await ctx.send(help_ui.prompt_for_role(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
             return
 
         role = role.lower()
         if role not in ["student", "teacher"]:
-            await ctx.send(help_ui.unknown_role_message(), delete_after=10)
+            await ctx.send(help_ui.unknown_role_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
             return
 
         commands = registry.get_commands_by_role(role)

--- a/commands/ping_command.py
+++ b/commands/ping_command.py
@@ -1,6 +1,7 @@
 import discord
 from commands.base import Command
 from ui import ping_ui  # 👈 import the UI module
+from core.constants import FEEDBACK_MESSAGE_DISPLAY_TIME
 
 
 class PingCommand(Command):
@@ -18,7 +19,7 @@ class PingCommand(Command):
         print("inside the ping command")
 
         embed = ping_ui.ping_response(latency)
-        await ctx.send(embed=embed, delete_after=5)
+        await ctx.send(embed=embed, delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
 
     def get_help_text(self):
         return f"!{self.name} - {self.description}"

--- a/commands/ping_command.py
+++ b/commands/ping_command.py
@@ -18,7 +18,7 @@ class PingCommand(Command):
         print("inside the ping command")
 
         embed = ping_ui.ping_response(latency)
-        await ctx.send(embed=embed)
+        await ctx.send(embed=embed, delete_after=5)
 
     def get_help_text(self):
         return f"!{self.name} - {self.description}"

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,0 +1,4 @@
+# constants.py
+
+FEEDBACK_MESSAGE_DISPLAY_TIME = 5 # e.g. Feedback messages, success confirmations
+USAGE_MESSAGE_DISPLAY_TIME = 10  # e.g. Usage instructions, help messages

--- a/tests/test_event_command.py
+++ b/tests/test_event_command.py
@@ -22,7 +22,7 @@ async def test_event_command_complete_usage(mock_ctx):
 
     # add event
     await event_command.execute(mock_ctx, ["add", event_name, due_time])
-    mock_ctx.send.assert_called_with(event_ui.event_added_message(mock_event))
+    mock_ctx.send.assert_called_with(event_ui.event_added_message(mock_event), delete_after=5)
 
     # list events
     await event_command.execute(mock_ctx, ["list"])
@@ -37,7 +37,7 @@ async def test_event_command_complete_usage(mock_ctx):
 
     # delete event
     await event_command.execute(mock_ctx, ["delete", str(event_id)])
-    mock_ctx.send.assert_called_with(event_ui.delete_result_message(deleted=True))
+    mock_ctx.send.assert_called_with(event_ui.delete_result_message(deleted=True), delete_after=5)
 
     # confirm deletion
     await event_command.execute(mock_ctx, ["list"])
@@ -54,7 +54,7 @@ async def test_event_command_add_missing_args(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["add"])
-    mock_ctx.send.assert_called_with(event_ui.add_usage_message())
+    mock_ctx.send.assert_called_with(event_ui.add_usage_message(), delete_after=10)
 
 
 @pytest.mark.asyncio
@@ -67,7 +67,7 @@ async def test_event_command_add_invalid_date(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["add", "TestEvent", "beautiful-day"])
-    mock_ctx.send.assert_called_with(event_ui.invalid_date_message())
+    mock_ctx.send.assert_called_with(event_ui.invalid_date_message(), delete_after=10)
 
 
 @pytest.mark.asyncio
@@ -80,7 +80,7 @@ async def test_event_command_delete_missing_id(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["delete"])
-    mock_ctx.send.assert_called_with(event_ui.delete_usage_message())
+    mock_ctx.send.assert_called_with(event_ui.delete_usage_message(), delete_after=10)
 
 
 @pytest.mark.asyncio
@@ -93,7 +93,7 @@ async def test_event_command_delete_non_integer_id(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["delete", "latest-event"])
-    mock_ctx.send.assert_called_with(event_ui.delete_usage_message())
+    mock_ctx.send.assert_called_with(event_ui.delete_usage_message(), delete_after=10)
 
 
 @pytest.mark.asyncio
@@ -106,4 +106,4 @@ async def test_event_command_unknown_action(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["do-something"])
-    mock_ctx.send.assert_called_with(event_ui.unknown_action_message())
+    mock_ctx.send.assert_called_with(event_ui.unknown_action_message(), delete_after=10)

--- a/tests/test_event_command.py
+++ b/tests/test_event_command.py
@@ -5,6 +5,7 @@ from commands.event_command import EventCommand
 from db.models.event import Event
 from ui import event_ui
 from types import SimpleNamespace
+from core.constants import USAGE_MESSAGE_DISPLAY_TIME, FEEDBACK_MESSAGE_DISPLAY_TIME
 
 
 @pytest.mark.asyncio
@@ -22,7 +23,7 @@ async def test_event_command_complete_usage(mock_ctx):
 
     # add event
     await event_command.execute(mock_ctx, ["add", event_name, due_time])
-    mock_ctx.send.assert_called_with(event_ui.event_added_message(mock_event), delete_after=5)
+    mock_ctx.send.assert_called_with(event_ui.event_added_message(mock_event), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
 
     # list events
     await event_command.execute(mock_ctx, ["list"])
@@ -37,7 +38,7 @@ async def test_event_command_complete_usage(mock_ctx):
 
     # delete event
     await event_command.execute(mock_ctx, ["delete", str(event_id)])
-    mock_ctx.send.assert_called_with(event_ui.delete_result_message(deleted=True), delete_after=5)
+    mock_ctx.send.assert_called_with(event_ui.delete_result_message(deleted=True), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
 
     # confirm deletion
     await event_command.execute(mock_ctx, ["list"])
@@ -54,7 +55,7 @@ async def test_event_command_add_missing_args(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["add"])
-    mock_ctx.send.assert_called_with(event_ui.add_usage_message(), delete_after=10)
+    mock_ctx.send.assert_called_with(event_ui.add_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio
@@ -67,7 +68,7 @@ async def test_event_command_add_invalid_date(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["add", "TestEvent", "beautiful-day"])
-    mock_ctx.send.assert_called_with(event_ui.invalid_date_message(), delete_after=10)
+    mock_ctx.send.assert_called_with(event_ui.invalid_date_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio
@@ -80,7 +81,7 @@ async def test_event_command_delete_missing_id(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["delete"])
-    mock_ctx.send.assert_called_with(event_ui.delete_usage_message(), delete_after=10)
+    mock_ctx.send.assert_called_with(event_ui.delete_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio
@@ -93,7 +94,7 @@ async def test_event_command_delete_non_integer_id(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["delete", "latest-event"])
-    mock_ctx.send.assert_called_with(event_ui.delete_usage_message(), delete_after=10)
+    mock_ctx.send.assert_called_with(event_ui.delete_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio
@@ -106,4 +107,4 @@ async def test_event_command_unknown_action(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["do-something"])
-    mock_ctx.send.assert_called_with(event_ui.unknown_action_message(), delete_after=10)
+    mock_ctx.send.assert_called_with(event_ui.unknown_action_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -28,7 +28,7 @@ async def test_help_command_no_role(mock_ctx):
     """
     help_command = HelpCommand()
     await help_command.execute(mock_ctx, role="")
-    mock_ctx.send.assert_called_with(help_ui.prompt_for_role())
+    mock_ctx.send.assert_called_with(help_ui.prompt_for_role(), delete_after=10)
 
 
 @pytest.mark.asyncio
@@ -41,7 +41,7 @@ async def test_help_command_invalid_role(mock_ctx):
     """
     help_command = HelpCommand()
     await help_command.execute(mock_ctx, role="admin")
-    mock_ctx.send.assert_called_with(help_ui.unknown_role_message())
+    mock_ctx.send.assert_called_with(help_ui.unknown_role_message(), delete_after=10)
 
 
 @pytest.mark.asyncio

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -4,6 +4,7 @@ from commands.help_command import HelpCommand
 from commands.event_command import EventCommand
 from commands.ping_command import PingCommand
 from ui import help_ui
+from core.constants import USAGE_MESSAGE_DISPLAY_TIME
 
 
 @pytest.fixture(autouse=True)
@@ -28,7 +29,7 @@ async def test_help_command_no_role(mock_ctx):
     """
     help_command = HelpCommand()
     await help_command.execute(mock_ctx, role="")
-    mock_ctx.send.assert_called_with(help_ui.prompt_for_role(), delete_after=10)
+    mock_ctx.send.assert_called_with(help_ui.prompt_for_role(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio
@@ -41,7 +42,7 @@ async def test_help_command_invalid_role(mock_ctx):
     """
     help_command = HelpCommand()
     await help_command.execute(mock_ctx, role="admin")
-    mock_ctx.send.assert_called_with(help_ui.unknown_role_message(), delete_after=10)
+    mock_ctx.send.assert_called_with(help_ui.unknown_role_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Remove feedback messages after 5 seconds.
Remove usage info related messaged after 10 seconds.
Keeping detailed messages like event list and command list in the chat.