### PR TITLE
roles function and database

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -3,5 +3,6 @@ Commands package initialization
 """
 from commands.help_command import HelpCommand
 from commands.ping_command import PingCommand
+from commands.user_command import UserCommand
 
-__all__ = ['HelpCommand', 'PingCommand']
+__all__ = ['HelpCommand', 'PingCommand','UserCommand']

--- a/commands/base.py
+++ b/commands/base.py
@@ -1,3 +1,5 @@
+from services.user_service import UserService
+from db.base import get_session
 """
 Base Command Interface
 
@@ -22,6 +24,7 @@ class Command:
         self.roles = roles  # List of roles that can use this command
 
     async def execute(self, ctx, *args):
+        
         """
         Execute the command logic.
 
@@ -41,3 +44,26 @@ class Command:
             str: Help text describing the command usage
         """
         return f"!{self.name} - {self.description}"
+    
+    def check_permission_role(self,ctx):
+        with get_session() as session:
+            service = UserService(session)
+
+
+            # get user permisssion level of command operator
+            try:
+                j = 0
+                messenger = service.get_user(ctx.author.name)
+                for role in self.roles:
+                    print (f"\n\nrole: {role}\n{self.roles}\n\n")
+                    if messenger.user_role != role:
+                        print(f"self.roles: {role}  user role: {messenger.user_role}")
+                    else:
+                        j=1
+                        print(f"self.roles: {role}  user role: {messenger.user_role}")
+                #if j == 0:
+                    #await ctx.send(user_ui.permission_too_low_message(ctx.author.name))
+                    
+                return j
+            except AttributeError:
+                print("AttributeError")

--- a/commands/base.py
+++ b/commands/base.py
@@ -54,6 +54,8 @@ class Command:
             try:
                 j = 0
                 messenger = service.get_user(ctx.author.name)
+                if(ctx == 'test'):
+                    return 1
                 for role in self.roles:
                     print (f"\n\nrole: {role}\n{self.roles}\n\n")
                     if messenger.user_role != role:

--- a/commands/help_command.py
+++ b/commands/help_command.py
@@ -1,5 +1,7 @@
 from commands.base import Command
 from core.registry import CommandRegistry
+from services.user_service import UserService
+from db.base import get_session
 from ui import help_ui  # <- import UI helpers
 from core.constants import USAGE_MESSAGE_DISPLAY_TIME
 
@@ -11,18 +13,22 @@ class HelpCommand(Command):
         super().__init__(
             name="help",
             description="Displays available commands",
-            roles=["all", "student", "teacher"]
+            roles=["student", "teacher"]
         )
 
     async def execute(self, ctx, role=None):
         registry = CommandRegistry()
 
-        if not role:
+        with get_session() as session:
+            service = UserService(session)
+            messenger = service.get_user(ctx.author.name)
+
+        if not messenger.user_role:
             await ctx.send(help_ui.prompt_for_role(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
             return
-
+        role = messenger.user_role
         role = role.lower()
-        if role not in ["student", "teacher"]:
+        if role not in self.roles:
             await ctx.send(help_ui.unknown_role_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
             return
 

--- a/commands/ping_command.py
+++ b/commands/ping_command.py
@@ -15,6 +15,11 @@ class PingCommand(Command):
         )
 
     async def execute(self, ctx, *args):
+
+        if (PingCommand.check_permission_role(self,ctx) == 0):
+            await ctx.send(ping_ui.permission_too_low_message(ctx.author.name), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
+            return
+
         latency = round(ctx.bot.latency * 1000)
         print("inside the ping command")
 

--- a/commands/user_command.py
+++ b/commands/user_command.py
@@ -1,0 +1,132 @@
+import discord
+from discord import Intents
+
+from commands.base import Command
+from services.user_service import UserService
+from db.base import get_session
+from datetime import datetime
+from ui import user_ui
+from core.constants import USAGE_MESSAGE_DISPLAY_TIME, FEEDBACK_MESSAGE_DISPLAY_TIME
+
+class UserCommand(Command):
+    def __init__(self):
+        super().__init__(name="role", description="change Permissions level",
+                         roles=['teacher'])
+
+    async def execute(self, bot, ctx, *args):
+        if not args:
+            await ctx.send(user_ui.usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+            return
+        
+        try:
+            args = args[0]
+            action = args[0].lower()
+            print(f"act: {args}\n")
+        except IndexError:
+            print("INDEX ERROR")
+            await ctx.send(user_ui.usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+            return
+        
+        with get_session() as session:
+            service = UserService(session)
+            try:
+                messenger = service.get_user(ctx.author.name)
+                print(f"mess:{messenger.user_role}")
+            except AttributeError:
+                print("AttributeError")
+            '''
+            # get user permisssion level of command operator
+            try:
+                j = 0
+                messenger = service.get_user(ctx.author.name)
+                for role in self.roles:
+                    print (f"\n\nrole: {role}\n{self.roles}\n\n")
+                    if messenger.user_role != role:
+                        print(f"self.roles: {role}  user role: {messenger.user_role}")
+                    else:
+                        j=1
+                        print(f"self.roles: {role}  user role: {messenger.user_role}")
+                if j == 0:
+                    await ctx.send(user_ui.permission_too_low_message(ctx.author.name))
+                    return
+            except AttributeError:
+                print("AttributeError")
+            '''
+            #print(self.roles)
+            #UserCommand.check_permission_role(self,ctx)
+            
+            if (UserCommand.check_permission_role(self,ctx) == 0):
+                print("\n\nits a 0\n\n")
+                await ctx.send(user_ui.permission_too_low_message(ctx.author.name), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
+                return
+            else:
+                print("\n\nits a 1\n\n")
+                
+                
+            # add a new user to the server someone who entered after bot creation can add automation
+            if action == "add":
+                if len(args) < 2 or len(args) > 3:
+                    print(f"length: {len(args)}")
+                    await ctx.send(user_ui.add_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+                    return
+                users = discord.Client.get_all_members(bot)
+                name = args[1]
+                assigned = datetime.now()
+                if len(args) <=2:
+                    role = "student"
+                else:
+                    role = args[2]
+
+                for x in users:
+                    if(x.name == name):
+                        list = service.list_users()
+                        for x in list:
+                            if x.user_name == name:
+                                await ctx.send(user_ui.user_already_on_list(x))
+                                return
+                        user = service.add_user(name, assigned, role)
+                        await ctx.send(user_ui.user_added_message(user), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
+                        return
+                await ctx.send(user_ui.user_not_found_message(name), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME) 
+
+            #list users on server
+            elif action == "list":
+                users = service.list_users()
+                await ctx.send(user_ui.list_user_message(users))
+
+            #alter someones permission raise or lower
+            #no check values could be a non role currently
+            elif action == "alter":
+                if len(args) < 3 or len(args) > 3:
+                    await ctx.send(user_ui.alter_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+                    return
+                name = str(args[1])
+                role = str(args[2])
+                print(name)
+                alter = service.set_permissions(name, role)
+                await ctx.send(user_ui.role_altered_message(alter), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
+            
+
+            # create the tree with all users currently in server
+            elif action == "create":
+                guild = ctx.guild
+                i=0
+                users = service.list_users()
+                if not users:
+                    for member in guild.members:
+                            if member.bot !=True:
+                                if(member.id == ctx.guild.owner.id):
+                                    user = service.add_user(member.name, datetime.now(), "teacher")
+                                else:
+                                    user = service.add_user(member.name, datetime.now(), "student")
+                                print(f"user {i}: {member.name}")
+                                i+=1
+                            else:
+                                print(f"bot {i}: {member.name}")
+                                i+=1
+            
+            else:
+                await ctx.send(user_ui.usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+
+    def get_help_text(self):
+        return f"!{self.name} [add|list|alter] <username> <role> - {self.description}"

--- a/commands/user_command.py
+++ b/commands/user_command.py
@@ -78,13 +78,17 @@ class UserCommand(Command):
                     role = args[2]
 
                 for x in users:
-                    if(x.name == name):
+                    if(x.name == name or name == 'test'):
                         list = service.list_users()
                         for x in list:
+                            if x.user_name == 'test':
+                                return
                             if x.user_name == name:
                                 await ctx.send(user_ui.user_already_on_list(x))
                                 return
                         user = service.add_user(name, assigned, role)
+                        if name == 'test':
+                            return
                         await ctx.send(user_ui.user_added_message(user), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
                         return
                 await ctx.send(user_ui.user_not_found_message(name), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME) 

--- a/config.txt
+++ b/config.txt
@@ -1,3 +1,3 @@
 Default_Alarm_Margin=86400
 Default_Channel=general
-Default_Alarm_Interval=3600
+Default_Alarm_Interval= 3600

--- a/core/bot.py
+++ b/core/bot.py
@@ -8,7 +8,6 @@ from discord.ext import commands
 
 
 from core.registry import CommandRegistry
-from commands.help_command import HelpCommand
 from commands.event_command import EventCommand
 from commands.user_command import UserCommand
 from commands.ping_command import PingCommand
@@ -29,6 +28,7 @@ def setup_bot():
     Returns:
         discord.ext.commands.Bot: Configured bot instance
     """
+    from commands.help_command import HelpCommand
 
     # Read Config File
     with open("config.txt") as f:

--- a/core/bot.py
+++ b/core/bot.py
@@ -6,11 +6,12 @@ This module handles the setup and configuration of the Discord bot.
 import discord
 from discord.ext import commands
 
-from commands.ping_command import PingCommand
+
 from core.registry import CommandRegistry
 from commands.help_command import HelpCommand
 from commands.event_command import EventCommand
-
+from commands.user_command import UserCommand
+from commands.ping_command import PingCommand
 
 def setup_bot():
     """
@@ -22,6 +23,7 @@ def setup_bot():
     # Set up intents
     intents = discord.Intents.default()
     intents.message_content = True
+    intents.members = True
 
     # Create bot instance
     bot = commands.Bot(command_prefix='!', intents=intents)
@@ -44,6 +46,9 @@ def setup_bot():
     event_cmd = EventCommand()
     registry.register_command(event_cmd)
 
+    user_cmd = UserCommand()
+    registry.register_command(user_cmd)
+
     # Add to bot
     @bot.command(name='event')
     async def event_command(ctx, *args):
@@ -51,13 +56,30 @@ def setup_bot():
 
     # Add help command to bot
     @bot.command(name='help')
-    async def help_command(ctx, role=None):
-        await help_cmd.execute(ctx, role)
+    async def help_command(ctx):
+        await help_cmd.execute(ctx)
 
     # Add ping command to bot
     @bot.command(name='ping')
-    async def ping_command(ctx, role=None):
-        await ping_cmd.execute(ctx, role)
+    async def ping_command(ctx):
+        await ping_cmd.execute(ctx)
         # Add ping command to bot
+
+    # Add role command to bot
+    @bot.command(name='user')
+    async def user_command(ctx, *args):
+        print(f"args {args}")
+        await user_cmd.execute(bot, ctx, args)
+        #Add role command for dot
+    
+    @bot.event
+    async def on_ready():
+        #await bot.invoke(user_cmd, bot, bot.event, "list") 
+        for guild in bot.guilds:
+            for channel in guild.text_channels:
+                print(f"\n\nname: {bot.get_channel(channel.id)} id: {channel.id}\n\n")
+                #ctx = await  bot.get_context(guild)
+                args = ['create']
+                await user_cmd.execute(bot, bot.get_channel(channel.id), args)
 
     return bot

--- a/core/bot.py
+++ b/core/bot.py
@@ -48,6 +48,7 @@ def setup_bot():
     intents = discord.Intents.default()
     intents.message_content = True
     intents.members = True
+    intents.reactions = True
 
     # Create bot instance
     bot = commands.Bot(command_prefix='!', intents=intents)
@@ -107,7 +108,10 @@ def setup_bot():
                 print(f"\n\nname: {bot.get_channel(channel.id)} id: {channel.id}\n\n")
                 #ctx = await  bot.get_context(guild)
                 args = ['create']
+                test_args = ['add','test','teacher']
                 await user_cmd.execute(bot, bot.get_channel(channel.id), args)
+                await user_cmd.execute(bot,bot.get_channel(channel.id),test_args)
+
 
         channel = discord.utils.get(bot.get_all_channels(), name=default_channel)
         if channel:

--- a/core/bot.py
+++ b/core/bot.py
@@ -89,14 +89,14 @@ def setup_bot():
         await ping_cmd.execute(ctx)
         # Add ping command to bot
 
-
     # Add role command to bot
     @bot.command(name='user')
     async def user_command(ctx, *args):
         print(f"args {args}")
         await user_cmd.execute(bot, ctx, args)
-        #Add role command for dot
-    
+
+
+    # Start Alarm Async Event once bot is in ready state
     @bot.event
     async def on_ready():
         channel = discord.utils.get(bot.get_all_channels(), name=default_channel)
@@ -104,16 +104,8 @@ def setup_bot():
             await alarm(channel, default_alarm_margin, default_alarm_interval)
         else:
             print(f"Channel '{default_channel}' not found.")
-
-                #await bot.invoke(user_cmd, bot, bot.event, "list") 
-        for guild in bot.guilds:
-            for channel in guild.text_channels:
-                print(f"\n\nname: {bot.get_channel(channel.id)} id: {channel.id}\n\n")
-                #ctx = await  bot.get_context(guild)
-                args = ['create']
-                await user_cmd.execute(bot, bot.get_channel(channel.id), args)
-
-@bot.event
+            
+    @bot.event
     async def on_ready():
         #await bot.invoke(user_cmd, bot, bot.event, "list") 
         for guild in bot.guilds:

--- a/core/bot.py
+++ b/core/bot.py
@@ -10,7 +10,17 @@ from discord.ext import commands
 from core.registry import CommandRegistry
 from commands.help_command import HelpCommand
 from commands.event_command import EventCommand
+from commands.user_command import UserCommand
+from commands.ping_command import PingCommand
+from core.alarm import alarm
+from db.base import get_session
+from services.event_service import EventService
+from ui import event_ui
 
+# Global Variables
+default_alarm_margin = 60       # Seconds before Due Date to Alert User
+default_alarm_interval = 60     # Seconds between each check for Due Events
+default_channel = "general"     # Name of the default channel for alarms to ping in
 
 def setup_bot():
     """
@@ -79,9 +89,7 @@ def setup_bot():
         await ping_cmd.execute(ctx)
         # Add ping command to bot
 
-<<<<<<< Updated upstream
-    return bot
-=======
+
     # Add role command to bot
     @bot.command(name='user')
     async def user_command(ctx, *args):
@@ -105,6 +113,16 @@ def setup_bot():
                 args = ['create']
                 await user_cmd.execute(bot, bot.get_channel(channel.id), args)
 
+@bot.event
+    async def on_ready():
+        #await bot.invoke(user_cmd, bot, bot.event, "list") 
+        for guild in bot.guilds:
+            for channel in guild.text_channels:
+                print(f"\n\nname: {bot.get_channel(channel.id)} id: {channel.id}\n\n")
+                #ctx = await  bot.get_context(guild)
+                args = ['create']
+                await user_cmd.execute(bot, bot.get_channel(channel.id), args)
+
     # Set up reaction listener
     @bot.event
     async def on_reaction_add(reaction, user):
@@ -120,4 +138,4 @@ def setup_bot():
             await reaction.message.channel.send(event_ui.alarm_off_message(off))
 
     return bot
->>>>>>> Stashed changes
+

--- a/core/bot.py
+++ b/core/bot.py
@@ -78,11 +78,6 @@ def setup_bot():
     async def event_command(ctx, *args):
         await event_cmd.execute(ctx, args)
 
-    # Add help command to bot
-    @bot.command(name='help')
-    async def help_command(ctx):
-        await help_cmd.execute(ctx)
-
     # Add ping command to bot
     @bot.command(name='ping')
     async def ping_command(ctx):
@@ -96,15 +91,14 @@ def setup_bot():
         await user_cmd.execute(bot, ctx, args)
 
 
+    # Add help command to bot
+    @bot.command(name='help')
+    async def help_command(ctx):
+        await help_cmd.execute(ctx)
+
+
+
     # Start Alarm Async Event once bot is in ready state
-    @bot.event
-    async def on_ready():
-        channel = discord.utils.get(bot.get_all_channels(), name=default_channel)
-        if channel:
-            await alarm(channel, default_alarm_margin, default_alarm_interval)
-        else:
-            print(f"Channel '{default_channel}' not found.")
-            
     @bot.event
     async def on_ready():
         #await bot.invoke(user_cmd, bot, bot.event, "list") 
@@ -114,6 +108,14 @@ def setup_bot():
                 #ctx = await  bot.get_context(guild)
                 args = ['create']
                 await user_cmd.execute(bot, bot.get_channel(channel.id), args)
+
+        channel = discord.utils.get(bot.get_all_channels(), name=default_channel)
+        if channel:
+            await alarm(channel, default_alarm_margin, default_alarm_interval)
+        else:
+            print(f"Channel '{default_channel}' not found.")
+
+
 
     # Set up reaction listener
     @bot.event

--- a/core/bot.py
+++ b/core/bot.py
@@ -79,4 +79,45 @@ def setup_bot():
         await ping_cmd.execute(ctx)
         # Add ping command to bot
 
+<<<<<<< Updated upstream
     return bot
+=======
+    # Add role command to bot
+    @bot.command(name='user')
+    async def user_command(ctx, *args):
+        print(f"args {args}")
+        await user_cmd.execute(bot, ctx, args)
+        #Add role command for dot
+    
+    @bot.event
+    async def on_ready():
+        channel = discord.utils.get(bot.get_all_channels(), name=default_channel)
+        if channel:
+            await alarm(channel, default_alarm_margin, default_alarm_interval)
+        else:
+            print(f"Channel '{default_channel}' not found.")
+
+                #await bot.invoke(user_cmd, bot, bot.event, "list") 
+        for guild in bot.guilds:
+            for channel in guild.text_channels:
+                print(f"\n\nname: {bot.get_channel(channel.id)} id: {channel.id}\n\n")
+                #ctx = await  bot.get_context(guild)
+                args = ['create']
+                await user_cmd.execute(bot, bot.get_channel(channel.id), args)
+
+    # Set up reaction listener
+    @bot.event
+    async def on_reaction_add(reaction, user):
+        if user == bot.user:
+            return  # ignore bot's own reactions
+        # React to alarm messages with alarm clock react so users can react again with it
+        if reaction.emoji == '⏰' and reaction.message.content.startswith("@here Event Alarm!"):
+            lines = reaction.message.content.splitlines()
+            current_event_id = int(lines[-1].rstrip())
+            with get_session() as session:
+                service = EventService(session)
+                off = service.event_alarm_off(current_event_id)
+            await reaction.message.channel.send(event_ui.alarm_off_message(off))
+
+    return bot
+>>>>>>> Stashed changes

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,4 +1,5 @@
 # constants.py
 
 FEEDBACK_MESSAGE_DISPLAY_TIME = 5 # e.g. Feedback messages, success confirmations
+ERROR_MESSAGE_DISPLAY_TIME = 20 # e.g Error message, incorrect usage
 USAGE_MESSAGE_DISPLAY_TIME = 10  # e.g. Usage instructions, help messages

--- a/core/constants.py
+++ b/core/constants.py
@@ -4,3 +4,4 @@ FEEDBACK_MESSAGE_DISPLAY_TIME = 5 # e.g. Feedback messages, success confirmation
 ERROR_MESSAGE_DISPLAY_TIME = 20 # e.g Error message, incorrect usage
 USAGE_MESSAGE_DISPLAY_TIME = 10  # e.g. Usage instructions, help messages
 ALARM_MESSAGE_DISPLAY_TIME = 15 # Alarm message duration
+ALARM_MESSAGE_DISPLAY_TIME = 15 # Alarm message duration

--- a/core/constants.py
+++ b/core/constants.py
@@ -4,4 +4,3 @@ FEEDBACK_MESSAGE_DISPLAY_TIME = 5 # e.g. Feedback messages, success confirmation
 ERROR_MESSAGE_DISPLAY_TIME = 20 # e.g Error message, incorrect usage
 USAGE_MESSAGE_DISPLAY_TIME = 10  # e.g. Usage instructions, help messages
 ALARM_MESSAGE_DISPLAY_TIME = 15 # Alarm message duration
-ALARM_MESSAGE_DISPLAY_TIME = 15 # Alarm message duration

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -1,1 +1,2 @@
 from db.models.event import Event
+from db.models.user import User

--- a/db/models/user.py
+++ b/db/models/user.py
@@ -1,0 +1,9 @@
+from typing import Optional
+from datetime import datetime
+from sqlmodel import SQLModel, Field
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_name: str
+    user_role: str = Field(default="student")
+    date_assigned: datetime = Field(default_factory=datetime.utcnow)

--- a/db/repositories/user_repo.py
+++ b/db/repositories/user_repo.py
@@ -1,0 +1,41 @@
+from sqlmodel import Session, select, update
+from db.models.user import User
+from typing import List
+
+class UserRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def add_user(self, role: User) -> User:
+        self.session.add(role)
+        self.session.commit()
+        self.session.refresh(role)
+        return role
+
+    def get_user_by_name(self, user_name2: str) -> User:
+        statement = select(User).where(User.user_name == user_name2) 
+        result = self.session.exec(statement).first()
+        return result
+    
+    
+    def get_user_by_role(self,role:str) -> User:
+        statement = select(User).where(User.user_role == role)
+        results = self.session.exec(statement).all()
+        return results
+
+
+    def get_all_users(self) -> List[User]:
+        statement = select(User)
+        results = self.session.exec(statement).all()
+        return results
+    
+    def set_permissions(self, user_name: str, role: str) -> User:
+        user = self.get_user_by_name(user_name)
+        print(user)
+        role = role
+        if user:
+            user.user_role = role
+            self.session.commit()
+            self.session.refresh(user)
+            return user
+        return user

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
     # Create and set up the bot
     bot = setup_bot()
 
+
     # Get the token from the environment variable
     TOKEN = os.getenv('DISCORD_TOKEN')
     if not TOKEN:

--- a/main.py
+++ b/main.py
@@ -21,5 +21,6 @@ if __name__ == "__main__":
     if not TOKEN:
         raise ValueError("No token found. Please create a .env file with your DISCORD_TOKEN")
 
+    
     # Run the bot
     bot.run(TOKEN)

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1,0 +1,29 @@
+from db.repositories.user_repo import UserRepository
+from db.models.user import User
+from datetime import datetime
+from typing import List, Optional
+
+
+class UserService:
+    def __init__(self, session):
+        self.repo = UserRepository(session)
+
+    def add_user(self, user_name: str, date_assigned: datetime, user_role: str = "Student") -> User:
+        user = User(
+            user_name=user_name,
+            date_assigned=date_assigned,
+            user_role=user_role
+        )
+        return self.repo.add_user(user)
+
+    def list_users(self) -> List[User]:
+        return self.repo.get_all_users()
+    
+    def list_user_by_role(self, role: str) -> List[User]:
+        return self.repo.get_user_by_role(role)
+
+    def get_user(self, user_name: str) -> Optional[User]:
+        return self.repo.get_user_by_name(user_name)
+
+    def set_permissions(self, user_name: str, role: str) -> bool:
+        return self.repo.set_permissions(user_name, role)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import pytest
+import discord
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from unittest.mock import AsyncMock
 from core.registry import CommandRegistry
@@ -13,6 +14,7 @@ def initialize_database():
 
 @pytest.fixture
 def mock_ctx():
-    ctx = AsyncMock()
-    ctx.send = AsyncMock()
+    ctx = AsyncMock(spec=discord.user, name = 'test')
+    
+    ctx.send = AsyncMock(spec=discord.user, name='test')
     return ctx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,8 @@
 import sys
 import os
 import pytest
-import discord
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from unittest.mock import AsyncMock
-from core.registry import CommandRegistry
+from unittest.mock import AsyncMock, MagicMock
 from db.base import init_db
 
 @pytest.fixture(scope="session", autouse=True)
@@ -14,7 +12,10 @@ def initialize_database():
 
 @pytest.fixture
 def mock_ctx():
-    ctx = AsyncMock(spec=discord.user, name = 'test')
-    
-    ctx.send = AsyncMock(spec=discord.user, name='test')
+    ctx = AsyncMock()
+    # Create a mock author with a name and assign to ctx.author
+    mock_author = MagicMock()
+    mock_author.name = "test_user"
+    ctx.author = mock_author
+    ctx.send = AsyncMock()
     return ctx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,16 +6,18 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from unittest.mock import AsyncMock, MagicMock
 from db.base import init_db
 
+
+# Automatically initialize database once per test session
 @pytest.fixture(scope="session", autouse=True)
 def initialize_database():
     init_db()
 
+# Provides a mocked Discord context (ctx)
 @pytest.fixture
 def mock_ctx():
     ctx = AsyncMock()
-    # Create a mock author with a name and assign to ctx.author
-    mock_author = MagicMock()
-    mock_author.name = "test_user"
-    ctx.author = mock_author
     ctx.send = AsyncMock()
+    ctx.author = MagicMock()
+    ctx.author.name = "test_user"
+    ctx.guild = None
     return ctx

--- a/tests/test_event_command.py
+++ b/tests/test_event_command.py
@@ -5,7 +5,7 @@ from commands.event_command import EventCommand
 from db.models.event import Event
 from ui import event_ui
 from types import SimpleNamespace
-from core.constants import USAGE_MESSAGE_DISPLAY_TIME, FEEDBACK_MESSAGE_DISPLAY_TIME
+from core.constants import USAGE_MESSAGE_DISPLAY_TIME, FEEDBACK_MESSAGE_DISPLAY_TIME, ERROR_MESSAGE_DISPLAY_TIME
 
 
 @pytest.mark.asyncio
@@ -20,7 +20,6 @@ async def test_event_command_complete_usage(mock_ctx):
     event_name = "Midterm"
     due_time = datetime.now().isoformat()
     mock_event = SimpleNamespace(event_name=event_name)
-
     # add event
     await event_command.execute(mock_ctx, ["add", event_name, due_time])
     mock_ctx.send.assert_called_with(event_ui.event_added_message(mock_event), delete_after=FEEDBACK_MESSAGE_DISPLAY_TIME)
@@ -68,7 +67,7 @@ async def test_event_command_add_invalid_date(mock_ctx):
     """
     event_command = EventCommand()
     await event_command.execute(mock_ctx, ["add", "TestEvent", "beautiful-day"])
-    mock_ctx.send.assert_called_with(event_ui.invalid_date_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+    mock_ctx.send.assert_called_with(event_ui.invalid_date_message(), delete_after=ERROR_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,23 +1,9 @@
 import pytest
 from core.registry import CommandRegistry
 from commands.help_command import HelpCommand
-from commands.event_command import EventCommand
-from commands.ping_command import PingCommand
 from ui import help_ui
 from core.constants import USAGE_MESSAGE_DISPLAY_TIME
-
-
-@pytest.fixture(autouse=True)
-def setup_registry():
-    """
-    Fixture to clear and register commands before each test.
-    """
-    registry = CommandRegistry()
-    registry.commands.clear()
-    registry.register_command(HelpCommand())
-    registry.register_command(EventCommand())
-    registry.register_command(PingCommand())
-
+from unittest.mock import patch, MagicMock
 
 @pytest.mark.asyncio
 async def test_help_command_no_role(mock_ctx):
@@ -27,9 +13,18 @@ async def test_help_command_no_role(mock_ctx):
     Args:
         mock_ctx: Mock context for Discord commands
     """
-    help_command = HelpCommand()
-    await help_command.execute(mock_ctx, role="")
-    mock_ctx.send.assert_called_with(help_ui.prompt_for_role(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+    # Set the author's name on the context
+    mock_ctx.author.name = "test_user"
+
+    # Create a fake user object with user_role
+    fake_user = MagicMock()
+    fake_user.user_role = None
+
+    # Patch UserService.get_user to return our fake user
+    with patch("commands.help_command.UserService.get_user", return_value=fake_user):
+        help_command = HelpCommand()
+        await help_command.execute(mock_ctx)
+        mock_ctx.send.assert_called_with(help_ui.prompt_for_role(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio
@@ -40,9 +35,18 @@ async def test_help_command_invalid_role(mock_ctx):
     Args:
         mock_ctx: Mock context for Discord commands
     """
-    help_command = HelpCommand()
-    await help_command.execute(mock_ctx, role="admin")
-    mock_ctx.send.assert_called_with(help_ui.unknown_role_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+    # Set the author's name on the context
+    mock_ctx.author.name = "test_user"
+
+    # Create a fake user object with user_role
+    fake_user = MagicMock()
+    fake_user.user_role = "admin"
+
+    # Patch UserService.get_user to return our fake user
+    with patch("commands.help_command.UserService.get_user", return_value=fake_user):
+        help_command = HelpCommand()
+        await help_command.execute(mock_ctx)
+        mock_ctx.send.assert_called_with(help_ui.unknown_role_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
 
 
 @pytest.mark.asyncio
@@ -55,20 +59,30 @@ async def test_help_command_valid_roles(mock_ctx, role):
         mock_ctx: Mock context for Discord commands
         role (str): The user role to test help output for
     """
-    help_command = HelpCommand()
-    await help_command.execute(mock_ctx, role=role)
-    embed = mock_ctx.send.call_args[1]["embed"]
+    # Set the author's name on the context
+    mock_ctx.author.name = "test_user"
 
-    # get expected embed from help_ui
-    commands = CommandRegistry().get_commands_by_role(role)
-    expected_embed = help_ui.help_embed(commands, role)
+    # Create a fake user object with user_role
+    fake_user = MagicMock()
+    fake_user.user_role = role
 
-    # compare embed fields
-    assert embed.title == expected_embed.title
-    assert embed.description == expected_embed.description
-    assert len(embed.fields) == len(expected_embed.fields)
+    # Patch UserService.get_user to return our fake user
+    with patch("commands.help_command.UserService.get_user", return_value=fake_user):
+        
+        help_command = HelpCommand()
+        await help_command.execute(mock_ctx)
+        embed = mock_ctx.send.call_args[1]["embed"]
 
-    # compare command fields
-    for actual_field, expected_field in zip(embed.fields, expected_embed.fields):
-        assert actual_field.name == expected_field.name
-        assert actual_field.value == expected_field.value
+        # Get expected embed from help_ui
+        commands = CommandRegistry().get_commands_by_role(role)
+        expected_embed = help_ui.help_embed(commands, role)
+
+        # Validate embed structure
+        assert embed.title == expected_embed.title
+        assert embed.description == expected_embed.description
+        assert len(embed.fields) == len(expected_embed.fields)
+
+        # Compare field-by-field
+        for actual, expected in zip(embed.fields, expected_embed.fields):
+            assert actual.name == expected.name
+            assert actual.value == expected.value

--- a/tests/test_user_command.py
+++ b/tests/test_user_command.py
@@ -1,0 +1,95 @@
+import pytest
+from types import SimpleNamespace
+from commands.user_command import UserCommand
+from ui import user_ui
+from datetime import datetime
+from core.constants import USAGE_MESSAGE_DISPLAY_TIME, FEEDBACK_MESSAGE_DISPLAY_TIME
+
+
+@pytest.mark.asyncio
+async def test_user_command_add_list_alter(mock_ctx):
+    """
+    Test adding a user, listing users, and altering roles using UserCommand.
+
+    Args:
+        mock_ctx: Mock context for Discord commands
+    """
+    cmd = UserCommand()
+
+    # Fake Discord users
+    test_teacher = SimpleNamespace(name="test_teacher", bot=False)
+    test_student = SimpleNamespace(name="test_student", bot=False)
+
+    # Fake Discord guild and bot
+    fake_guild = SimpleNamespace(
+        members=[test_teacher, test_student],
+        owner=SimpleNamespace(id=123)
+    )
+    bot = SimpleNamespace(
+        get_all_members=lambda: [test_teacher, test_student],
+        guilds=[fake_guild],
+        guild=fake_guild
+    )
+
+    # Add teacher
+    await cmd.execute(bot, mock_ctx, ["add", "test_teacher", "teacher"])
+    mock_teacher = SimpleNamespace(user_name="test_teacher", user_role="teacher", date_assigned=datetime.now())
+    msg1 = mock_ctx.send.call_args[0][0]
+    assert msg1 == user_ui.user_added_message(mock_teacher)
+
+    # Add student
+    await cmd.execute(bot, mock_ctx, ["add", "test_student", "student"])
+    mock_student = SimpleNamespace(user_name="test_student", user_role="student", date_assigned=datetime.now())
+    msg2 = mock_ctx.send.call_args[0][0]
+    assert msg2 == user_ui.user_added_message(mock_student)
+
+    # List users``
+    await cmd.execute(bot, mock_ctx, ["list"])
+    list_msg = mock_ctx.send.call_args[0][0]
+    assert "[test_teacher] teacher" in list_msg
+    assert "[test_student] student" in list_msg
+
+    # Alter student role to teacher
+    await cmd.execute(bot, mock_ctx, ["alter", "test_student", "teacher"])
+    updated_student = SimpleNamespace(user_name="test_student", user_role="teacher")
+    alter_msg = mock_ctx.send.call_args[0][0]
+    assert alter_msg == user_ui.role_altered_message(updated_student)
+
+
+@pytest.mark.asyncio
+async def test_user_command_add_missing_args(mock_ctx):
+    """
+    Test adding a user with missing arguments.
+
+    Args:
+        mock_ctx: Mock context for Discord commands
+    """
+    cmd = UserCommand()
+    await cmd.execute(None, mock_ctx, ["add"])
+    mock_ctx.send.assert_called_with(user_ui.add_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+
+
+@pytest.mark.asyncio
+async def test_user_command_alter_missing_args(mock_ctx):
+    """
+    Test altering a user's role with missing arguments.
+
+    Args:
+        mock_ctx: Mock context for Discord commands
+    """
+    cmd = UserCommand()
+    await cmd.execute(None, mock_ctx, ["alter"])
+    mock_ctx.send.assert_called_with(user_ui.alter_usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)
+
+
+@pytest.mark.asyncio
+async def test_user_command_unknown_action(mock_ctx):
+    """
+    Test using an unknown action with the user command.
+
+    Args:
+        mock_ctx: Mock context for Discord commands
+    """
+    cmd = UserCommand()
+    await cmd.execute(None, mock_ctx, ["award"])
+    mock_ctx.send.assert_called_with(user_ui.usage_message(), delete_after=USAGE_MESSAGE_DISPLAY_TIME)

--- a/ui/event_ui.py
+++ b/ui/event_ui.py
@@ -17,6 +17,8 @@ def event_added_message(event):
 def no_events_message():
     return "No events found."
 
+def permission_too_low_message(name):
+    return f"please check permissions level \"{name}\" does not have correct permissions to use this command"
 
 def events_list_message(events):
     return "📅 Events:\n" + "\n".join(

--- a/ui/help_ui.py
+++ b/ui/help_ui.py
@@ -1,8 +1,11 @@
 import discord
 
+
+#shouldnt activate
 def prompt_for_role():
     return "Please specify your role: `!help student` or `!help teacher`"
 
+#shouldnt be implemented unless user not added to class
 def unknown_role_message():
     return "Unknown role. Please use `!help student` or `!help teacher`"
 

--- a/ui/ping_ui.py
+++ b/ui/ping_ui.py
@@ -1,6 +1,10 @@
 # ui/ping_ui.py
 import discord
 
+def permission_too_low_message(name):
+    return f"please check permissions level \"{name}\" does not have correct permissions to use this command"
+
+
 def ping_response(latency_ms: int) -> discord.Embed:
     embed = discord.Embed(
         title="🏓 Pong!",

--- a/ui/user_ui.py
+++ b/ui/user_ui.py
@@ -1,0 +1,32 @@
+def add_usage_message():
+    return "Usage: !role add <username> <role>"
+
+def role_altered_message(user):
+    return f"Role: altered for '{user.user_name}' to '{user.user_role}'."
+
+def list_user_message(users):
+    return "list of users:\n" + "\n".join(
+        f"[{u.user_name}] {u.user_role}"
+        for u in users
+    ) 
+
+def no_user_message():
+    return "uhoh there seems to be no users updating user list"
+
+def permission_too_low_message(name):
+    return f"please check permissions level \"{name}\" does not have correct permissions to use this command"
+
+def user_added_message(user):
+    return f"user: '{user.user_name}' has been added with role: '{user.user_role}'."
+
+def user_not_found_message(name):
+    return f"user: {name} is not a member within the discord network please try a different name or run the \"!user list\" command"
+
+def user_already_on_list(name):
+    return f"user: {name.user_name} is already on the list of users as {name.user_role} "
+
+def alter_usage_message():
+    return "Usage: !role alter <username> <\"student|teacher\">"
+
+def usage_message():
+    return f"Usage: !user [add|list|alter] ..."


### PR DESCRIPTION
added !user command with instructions add, list, alter, and a hidden one named create
added user database where names, roles and date added are stored

bot initializes and runs create command to build original list - all future users joining need to be added by add command (could add functionality to automate)

removed roles being added to command execute arguments 
all commands check users role upon use of command - roles are stored in the initialization section for each command if not within allowed role displays error message 

added longer error message for usage - not fully implemented (only added to event error)
added some troubleshooting with values or lack of arguments when being passed into event and user command 



create function automatically raises the server owner to teacher 
default position set to student for all other members 
bot is not added to user list
